### PR TITLE
New data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nosetests.xml
 /.idea/
 
 /figgy.db.sqlite3
+
+# Local settings
+local.py

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ nosetests.xml
 
 # Local settings
 local.py
+_local_tests.py

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ This setup assumes you have just cloned the git repo and are in the directory wi
     $ cp figgy/local.py.example figgy/local.py             # Your local.py is your personal settings. Edit them later.
     $ python manage.py syncdb --noinput                    # Fill out the database schema
     $ python manage.py createsuperuser                     # Establish an admin so you can log in
+    $ python manage.py migrate                             # Run any migrations that have been created
     $ python manage.py runserver                           # Prove this works by visiting http://localhost:8000
 
 Before you write any code, make sure you can run the tests and get them to pass 100%.
+
+Note: If you have worked on this project before, you will need to run a fake migration to apply the first migration
+without actually trying to create any tables.
 
 ### Every time
 
@@ -34,7 +38,7 @@ sure you have any new dependencies or schema modifications:
 
     $ . ve/bin/activate                           # Turn on the virtualenv (Every time!)
     $ python setup.py develop --always-unzip      # Update the virtualenv with new Python dependencies
-    $ python manage.py syncdb --noinput           # Make sure the database schema is still filled out
+    $ python manage.py migrate                    # Make sure the database schema is up to date
     $ python manage.py runserver                  # Prove this works by visiting http://localhost:8000
 
 tc.

--- a/data/update/update-4.xml
+++ b/data/update/update-4.xml
@@ -1,0 +1,9 @@
+<book id="book-1">
+    <!-- this should match on the canonical book id for book-1 -->
+    <title>this is the first book, 3rd edition</title>
+    <description>A short description about the first book. Third edition.</description>
+    <aliases>
+        <alias scheme="ISBN-10" value="1000000031"/>
+        <alias scheme="ISBN-13" value="1000000000031"/>
+    </aliases>
+</book>

--- a/figgy/_test_settings.py
+++ b/figgy/_test_settings.py
@@ -1,3 +1,4 @@
+from termcolor import colored
 from figgy.settings import *
 
 DEBUG = False
@@ -63,6 +64,5 @@ TESTING = True
 try:
     from figgy._local_tests import *
 except ImportError, e:
-    print u"FYI: You have no figgy/_local_tests.py, but you should!"
+    print colored(u"FYI: You have no figgy/_local_tests.py, but you should!", "yellow")
     pass
-

--- a/figgy/settings.py
+++ b/figgy/settings.py
@@ -38,6 +38,8 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django_nose',
 
+    'south',
+
     'storage',
 
 )

--- a/figgy/settings.py
+++ b/figgy/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'django_nose',
 
     'south',
+    'django_extensions',
 
     'storage',
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         # 'cssselect',
 
         'django-nose',
-        'tox<1.8',
+        'tox<=1.8',
         'termcolor<=1.2',
     ],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
 
         'django-nose',
         'tox<1.8',
+        'termcolor<=1.2',
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'tox<=1.8',
         'termcolor<=1.2',
         'South<=0.8',
+        'django-extensions<=1.3',
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'django-nose',
         'tox<=1.8',
         'termcolor<=1.2',
+        'South<=0.8',
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         # 'cssselect',
 
         'django-nose',
+        'tox<1.8',
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/storage/admin.py
+++ b/storage/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from storage.models import Book, Alias
+from storage.models import Book, Alias, Edition
 
 
 class InlineAliasAdmin(admin.StackedInline):
@@ -8,10 +8,13 @@ class InlineAliasAdmin(admin.StackedInline):
     extra = 0
 
 
-class BookAdmin(admin.ModelAdmin):
+class EditionAdmin(admin.ModelAdmin):
     inlines = [InlineAliasAdmin]
 
-    list_display = ['id', 'title', 'list_aliases']
+    list_display = ['id', 'title', 'edition_number', 'list_aliases']
+    ordering = ['title', 'edition_number']
+
+    fields = ['book', 'title', 'edition_number', 'description']
 
     def list_aliases(self, obj):
         if obj:
@@ -19,6 +22,22 @@ class BookAdmin(admin.ModelAdmin):
 
     list_aliases.allow_tags = True
 
+
+class InlineEditionAdmin(admin.StackedInline):
+    model = Edition
+    extra = 0
+
+
+class BookAdmin(admin.ModelAdmin):
+    inlines = [InlineEditionAdmin]
+    list_display = ['id', 'title', 'list_editions']
+
+    def list_editions(self, obj):
+        if obj:
+            return '<pre>%s</pre>' % '\n'.join([o.title for o in obj.editions.all()])
+
+    list_editions.allow_tags = True
+
+
 admin.site.register(Book, BookAdmin)
-
-
+admin.site.register(Edition, EditionAdmin)

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -2,6 +2,7 @@
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:56 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
+from termcolor import colored
 from django.core.management.base import BaseCommand, CommandError
 
 from lxml import etree
@@ -17,4 +18,5 @@ class Command(BaseCommand):
             with open(filename, 'rb') as fh:
                 print "\nImporting %s into database." % filename
                 book_node = etree.parse(fh).getroot()
-                storage.tools.process_book_element(book_node)
+                status = storage.tools.process_book_element(book_node)
+                print status

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -15,6 +15,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for filename in args:
             with open(filename, 'rb') as fh:
-                print "Importing %s into database." % filename
+                print "\nImporting %s into database." % filename
                 book_node = etree.parse(fh).getroot()
                 storage.tools.process_book_element(book_node)

--- a/storage/migrations/0001_initial.py
+++ b/storage/migrations/0001_initial.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Book'
+        db.create_table(u'storage_book', (
+            ('created_time', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('last_modified_time', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, db_index=True, blank=True)),
+            ('id', self.gf('django.db.models.fields.CharField')(max_length=30, primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=128, db_index=True)),
+            ('description', self.gf('django.db.models.fields.TextField')(default=None, null=True, blank=True)),
+        ))
+        db.send_create_signal(u'storage', ['Book'])
+
+        # Adding model 'Alias'
+        db.create_table(u'storage_alias', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created_time', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('last_modified_time', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, db_index=True, blank=True)),
+            ('book', self.gf('django.db.models.fields.related.ForeignKey')(related_name='aliases', to=orm['storage.Book'])),
+            ('value', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, db_index=True)),
+            ('scheme', self.gf('django.db.models.fields.CharField')(max_length=40)),
+        ))
+        db.send_create_signal(u'storage', ['Alias'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Book'
+        db.delete_table(u'storage_book')
+
+        # Deleting model 'Alias'
+        db.delete_table(u'storage_alias')
+
+
+    models = {
+        u'storage.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'aliases'", 'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'scheme': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'value': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'})
+        },
+        u'storage.book': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Book'},
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '30', 'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['storage']

--- a/storage/migrations/0002_auto__add_edition__add_field_alias_edition.py
+++ b/storage/migrations/0002_auto__add_edition__add_field_alias_edition.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Edition'
+        db.create_table(u'storage_edition', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('created_time', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('last_modified_time', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, db_index=True, blank=True)),
+            ('book', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['storage.Book'])),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=128, db_index=True)),
+            ('description', self.gf('django.db.models.fields.TextField')(default=None, null=True, blank=True)),
+            ('edition_number', self.gf('django.db.models.fields.IntegerField')(default=1, null=True, blank=True)),
+        ))
+        db.send_create_signal(u'storage', ['Edition'])
+
+        # Adding field 'Alias.edition'
+        db.add_column(u'storage_alias', 'edition',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['storage.Edition'], null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'Edition'
+        db.delete_table(u'storage_edition')
+
+        # Deleting field 'Alias.edition'
+        db.delete_column(u'storage_alias', 'edition_id')
+
+
+    models = {
+        u'storage.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'aliases'", 'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'edition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Edition']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'scheme': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'value': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'})
+        },
+        u'storage.book': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Book'},
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '30', 'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        u'storage.edition': {
+            'Meta': {'object_name': 'Edition'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'edition_number': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['storage']

--- a/storage/migrations/0003_edition_data.py
+++ b/storage/migrations/0003_edition_data.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        for book in orm.Book.objects.all():
+            # create an edition for each book and move all aliases to edition
+            edition = orm.Edition(title=book.title, description=book.description)
+            edition.book = book
+            edition.save()
+            aliases = book.aliases.all()
+            for alias in aliases:
+                scheme = alias.scheme
+                value = alias.value
+                alias.delete()
+                alias = orm.Alias.objects.create(scheme=scheme, value=value, edition=edition, book=book)
+                alias.save()
+            edition.save()
+            book.save()
+
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        u'storage.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'aliases'", 'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'edition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Edition']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'scheme': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'value': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'})
+        },
+        u'storage.book': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Book'},
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '30', 'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        u'storage.edition': {
+            'Meta': {'object_name': 'Edition'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'edition_number': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['storage']
+    symmetrical = True

--- a/storage/migrations/0004_auto__del_field_alias_book.py
+++ b/storage/migrations/0004_auto__del_field_alias_book.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Alias.book'
+        db.delete_column(u'storage_alias', 'book_id')
+
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'Alias.book'
+        raise RuntimeError("Cannot reverse this migration. 'Alias.book' and its values cannot be restored.")
+
+    models = {
+        u'storage.alias': {
+            'Meta': {'object_name': 'Alias'},
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'edition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'aliases'", 'null': 'True', 'to': u"orm['storage.Edition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'scheme': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'value': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'db_index': 'True'})
+        },
+        u'storage.book': {
+            'Meta': {'ordering': "['title']", 'object_name': 'Book'},
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '30', 'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        u'storage.edition': {
+            'Meta': {'object_name': 'Edition'},
+            'book': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Book']"}),
+            'created_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'edition_number': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_time': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['storage']

--- a/storage/models.py
+++ b/storage/models.py
@@ -4,7 +4,9 @@ from django.db import models
 
 
 class BaseModel(models.Model):
-    '''Base class for all models'''
+    """
+    Base class for all models
+    """
     created_time = models.DateTimeField('date created', auto_now_add=True)
     last_modified_time = models.DateTimeField('last-modified', auto_now=True, db_index=True)
 
@@ -14,11 +16,11 @@ class BaseModel(models.Model):
 
 class BookManager(models.Manager):
     def get_by_isbn_10(self, isbn_10):
-        '''
+        """
         Get a book by its ISBN-10 code.
 
         :returns: a book or None
-        '''
+        """
         try:
             return Book.objects.get(aliases__scheme='ISBN-10', aliases__value=isbn_10)
         except Book.DoesNotExist:
@@ -26,12 +28,15 @@ class BookManager(models.Manager):
 
 
 class Book(BaseModel):
-    '''
+    """
     Main storage for a Book object.
-    '''
-    id = models.CharField(max_length=30, primary_key=True, help_text="The primary identifier of this title, we get this value from publishers.")
-    title = models.CharField(max_length=128, help_text="The title of this book.", db_index=True, null=False, blank=False)
-    description = models.TextField(blank=True, null=True, default=None, help_text="Very short description of this book.")
+    """
+    id = models.CharField(max_length=30, primary_key=True,
+                          help_text="The primary identifier of this title, we get this value from publishers.")
+    title = models.CharField(max_length=128, help_text="The title of this book.", db_index=True, null=False,
+                             blank=False)
+    description = models.TextField(blank=True, null=True, default=None,
+                                   help_text="Very short description of this book.")
     objects = BookManager()
 
     def __unicode__(self):
@@ -42,12 +47,12 @@ class Book(BaseModel):
 
 
 class Alias(BaseModel):
-    '''
+    """
     A book can have one or more aliases which
 
     For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13 (newer scheme),
     or any number of other aliases.
-    '''
+    """
     book = models.ForeignKey(Book, related_name='aliases')
     value = models.CharField(max_length=255, db_index=True, unique=True, help_text="The value of this identifier")
     scheme = models.CharField(max_length=40, help_text="The scheme of identifier")
@@ -57,11 +62,11 @@ class Alias(BaseModel):
 
     @classmethod
     def get_probable_matches(cls, aliases):
-        '''
+        """
         Finds the most probable matches for a book based on alias information, favoring a matching ISBN-10.
 
         :returns: the isbn-10 book match (or None) and a list of non-isbn-10 book matches
-        '''
+        """
         isbn_10_match = None
         non_isbn_10_matches = []
         for alias in aliases:

--- a/storage/models.py
+++ b/storage/models.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from django.db import models
+from django.db.models import Max
 
 
 class BaseModel(models.Model):
@@ -14,19 +15,6 @@ class BaseModel(models.Model):
         abstract = True
 
 
-class BookManager(models.Manager):
-    def get_by_isbn_10(self, isbn_10):
-        """
-        Get a book by its ISBN-10 code.
-
-        :returns: a book or None
-        """
-        try:
-            return Book.objects.get(aliases__scheme='ISBN-10', aliases__value=isbn_10)
-        except Book.DoesNotExist:
-            return None
-
-
 class Book(BaseModel):
     """
     Main storage for a Book object.
@@ -37,13 +25,48 @@ class Book(BaseModel):
                              blank=False)
     description = models.TextField(blank=True, null=True, default=None,
                                    help_text="Very short description of this book.")
-    objects = BookManager()
 
     def __unicode__(self):
         return u"Book %s" % self.title
 
     class Meta:
         ordering = ['title']
+
+    def get_next_edition_number(self):
+        highest = self.editions.all().aggregate(highest=Max('edition_number'))['highest']
+        if highest:
+            return highest + 1
+        else:
+            return 1
+
+
+class EditionManager(models.Manager):
+    def get_or_create_by_isbn_13(self, isbn_13, book_id):
+        """
+        Get an edition by its ISBN-13 code.
+        :returns: edition, edition_created, book_created
+        """
+        try:
+            return Edition.objects.get(aliases__scheme='ISBN-13', aliases__value=isbn_13), False, False
+        except Edition.DoesNotExist:
+            book, book_created = Book.objects.get_or_create(pk=book_id)
+            return Edition.objects.create(book=book), True, book_created
+
+
+class Edition(BaseModel):
+    """
+    Editions hold the unique information for an edition of a book, like aliases and new titles.
+    """
+    book = models.ForeignKey(Book, related_name='editions')
+    title = models.CharField(max_length=128, help_text="The title of this book.", db_index=True, null=False,
+                             blank=False)
+    description = models.TextField(blank=True, null=True, default=None,
+                                   help_text="Very short description of this book.")
+    edition_number = models.IntegerField(blank=True, null=True)
+    objects = EditionManager()
+
+    def __unicode__(self):
+        return u"Edition {} of book '{}'".format(self.edition_number, self.book.title)
 
 
 class Alias(BaseModel):
@@ -53,28 +76,9 @@ class Alias(BaseModel):
     For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13 (newer scheme),
     or any number of other aliases.
     """
-    book = models.ForeignKey(Book, related_name='aliases')
+    edition = models.ForeignKey(Edition, null=True, related_name='aliases')
     value = models.CharField(max_length=255, db_index=True, unique=True, help_text="The value of this identifier")
     scheme = models.CharField(max_length=40, help_text="The scheme of identifier")
 
     def __unicode__(self):
-        return '%s identifier for %s' % (self.scheme, self.book.title)
-
-    @classmethod
-    def get_probable_matches(cls, aliases):
-        """
-        Finds the most probable matches for a book based on alias information, favoring a matching ISBN-10.
-
-        :returns: the isbn-10 book match (or None) and a list of non-isbn-10 book matches
-        """
-        isbn_10_match = None
-        non_isbn_10_matches = []
-        for alias in aliases:
-            scheme = alias.get('scheme')
-            value = alias.get('value')
-            if scheme == 'ISBN-10':
-                isbn_10_match = Book.objects.get_by_isbn_10(value)
-            else:
-                non_isbn_10_matches += Alias.objects.filter(scheme=scheme, value=value)
-
-        return isbn_10_match, non_isbn_10_matches
+        return '%s identifier for %s' % (self.scheme, self.edition.title)

--- a/storage/models.py
+++ b/storage/models.py
@@ -12,14 +12,27 @@ class BaseModel(models.Model):
         abstract = True
 
 
+class BookManager(models.Manager):
+    def get_by_isbn_10(self, isbn_10):
+        '''
+        Get a book by its ISBN-10 code.
+
+        :returns: a book or None
+        '''
+        try:
+            return Book.objects.get(aliases__scheme='ISBN-10', aliases__value=isbn_10)
+        except Book.DoesNotExist:
+            return None
+
+
 class Book(BaseModel):
     '''
     Main storage for a Book object.
     '''
-
     id = models.CharField(max_length=30, primary_key=True, help_text="The primary identifier of this title, we get this value from publishers.")
     title = models.CharField(max_length=128, help_text="The title of this book.", db_index=True, null=False, blank=False)
     description = models.TextField(blank=True, null=True, default=None, help_text="Very short description of this book.")
+    objects = BookManager()
 
     def __unicode__(self):
         return u"Book %s" % self.title
@@ -35,10 +48,28 @@ class Alias(BaseModel):
     For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13 (newer scheme),
     or any number of other aliases.
     '''
-
     book = models.ForeignKey(Book, related_name='aliases')
     value = models.CharField(max_length=255, db_index=True, unique=True, help_text="The value of this identifier")
     scheme = models.CharField(max_length=40, help_text="The scheme of identifier")
 
     def __unicode__(self):
         return '%s identifier for %s' % (self.scheme, self.book.title)
+
+    @classmethod
+    def get_probable_matches(cls, aliases):
+        '''
+        Finds the most probable matches for a book based on alias information, favoring a matching ISBN-10.
+
+        :returns: the isbn-10 book match (or None) and a list of non-isbn-10 book matches
+        '''
+        isbn_10_match = None
+        non_isbn_10_matches = []
+        for alias in aliases:
+            scheme = alias.get('scheme')
+            value = alias.get('value')
+            if scheme == 'ISBN-10':
+                isbn_10_match = Book.objects.get_by_isbn_10(value)
+            else:
+                non_isbn_10_matches += Alias.objects.filter(scheme=scheme, value=value)
+
+        return isbn_10_match, non_isbn_10_matches

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -8,14 +8,18 @@ import uuid
 from django.test import TestCase
 
 from storage import models
+from storage.models import Alias, Book
+
 
 class TestModels(TestCase):
     def setUp(self):
         self.book = models.Book.objects.create(title="The Title", pk=str(uuid.uuid4()))
+        self.book.aliases.create(scheme='ISBN-10', value='1234567890')
 
     def test_book_have_unicode_method(self):
         '''The Book should have a __unicode__ method.'''
         expected = 'Book {}'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
 
-
+    def test_get_book_by_isbn(self):
+        self.assertEqual(self.book, Book.objects.get_by_isbn_10('1234567890'))

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -8,18 +8,19 @@ import uuid
 from django.test import TestCase
 
 from storage import models
-from storage.models import Alias, Book
+from storage.models import Alias, Book, Edition
 
 
 class TestModels(TestCase):
     def setUp(self):
         self.book = models.Book.objects.create(title="The Title", pk=str(uuid.uuid4()))
-        self.book.aliases.create(scheme='ISBN-10', value='1234567890')
+        self.edition = self.book.editions.create(title=self.book.title, book=self.book)
+        self.edition.aliases.create(scheme='ISBN-13', value='1234567890')
 
     def test_book_have_unicode_method(self):
         '''The Book should have a __unicode__ method.'''
         expected = 'Book {}'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
 
-    def test_get_book_by_isbn(self):
-        self.assertEqual(self.book, Book.objects.get_by_isbn_10('1234567890'))
+    def test_get_or_create_by_isbn_13(self):
+        self.assertEqual((self.edition, False, False), Edition.objects.get_or_create_by_isbn_13('1234567890', self.book.pk))

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 
 from django.test import TestCase
 from lxml import etree
-from storage.models import Book, Alias
+from storage.models import Book, Alias, Edition
 import storage.tools
 
 
@@ -18,6 +18,26 @@ class TestTools(TestCase):
             <aliases>
                 <alias scheme="ISBN-10" value="0158757819"/>
                 <alias scheme="ISBN-13" value="0000000000123"/>
+            </aliases>
+        </book>
+        '''
+
+        self.edition_2_xml_str = '''
+        <book id="12345">
+            <title>A title, Ed. 2</title>
+            <aliases>
+                <alias scheme="ISBN-10" value="0158757829"/>
+                <alias scheme="ISBN-13" value="0000000000456"/>
+            </aliases>
+        </book>
+        '''
+
+        self.edition_2_new_title_xml_str = '''
+        <book id="12345">
+            <title>A different title, Ed. 2</title>
+            <aliases>
+                <alias scheme="ISBN-10" value="0158757829"/>
+                <alias scheme="ISBN-13" value="0000000000456"/>
             </aliases>
         </book>
         '''
@@ -42,7 +62,7 @@ class TestTools(TestCase):
         book = Book.objects.get(pk='12345')
 
         self.assertEqual(book.title, 'A title')
-        self.assertEqual(book.aliases.count(), 2)
+        self.assertEqual(book.editions.all()[0].aliases.count(), 2)
         self.assertEqual(Alias.objects.get(scheme='ISBN-10').value, '0158757819')
         self.assertEqual(Alias.objects.get(scheme='ISBN-13').value, '0000000000123')
 
@@ -55,3 +75,22 @@ class TestTools(TestCase):
         xml = etree.fromstring(self.dupe_alias_book_xml_str)
         storage.tools.process_book_element(xml)
         self.assertEqual(1, Book.objects.count())  # invalid book was removed
+
+    def test_new_editions_are_saved(self):
+        """
+        Ensure books with duplicate aliases throw an exception
+        """
+        xml = etree.fromstring(self.valid_book_xml_str)
+        storage.tools.process_book_element(xml)
+        xml = etree.fromstring(self.edition_2_xml_str)
+        storage.tools.process_book_element(xml)
+        self.assertEqual(1, Book.objects.count())
+        self.assertEqual(2, Edition.objects.count())
+
+    def test_editions_can_be_updated(self):
+        xml = etree.fromstring(self.edition_2_xml_str)
+        storage.tools.process_book_element(xml)
+        xml = etree.fromstring(self.edition_2_new_title_xml_str)
+        storage.tools.process_book_element(xml)
+        self.assertEqual(1, Book.objects.count())
+        self.assertEqual(1, Edition.objects.count())

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -16,28 +16,43 @@ def process_book_element(book_element):
     :returns:
     """
 
-    book, created = Book.objects.get_or_create(pk=book_element.get('id'))
+    book, book_created = Book.objects.get_or_create(pk=book_element.get('id'))
     book.title = book_element.findtext('title')
     book.description = book_element.findtext('description')
 
     errors = []
-    for alias in book_element.xpath('aliases/alias'):
+    aliases = [alias for alias in book_element.xpath('aliases/alias')]
+    created_aliases = []
+    for alias in aliases:
         scheme = alias.get('scheme')
         value = alias.get('value')
-
         try:
-            book.aliases.get_or_create(scheme=scheme, value=value)
+            created_alias, created = book.aliases.get_or_create(scheme=scheme, value=value)
+            if created:
+                created_aliases.append(created_alias)
         except IntegrityError, e:
             # tried to create alias, but value clashed with another book's alias
             existing_alias = Alias.objects.get(value=value)
             errors.append('Duplicate {} found on book "{}" with value {}'.format(scheme, existing_alias.book.id, value))
 
     if errors:
-        print colored('"{}" not saved'.format(book.title), 'red')
+        # here we tell the user about errors and suggest book xml files to fix
+        print colored('"{}" not saved'.format(book.id), 'red')
         for error in errors:
             print colored(error, 'yellow')
-        if created:
+
+        print colored("Did you mean to update or add a new edition for one of the following?", "blue")
+        isbn_10_match, other_matches = Alias.get_probable_matches(aliases)
+        if isbn_10_match:
+            print colored("**ISBN-10 match: {}".format(isbn_10_match.id), "blue", attrs=['bold'])
+        for match in other_matches:
+            print colored("{} match: {}".format(match.scheme, match.book.id), "blue")
+
+        # do not proceed with any created books or aliases if there have been errors
+        if book_created:
             book.delete()
+        for alias in created_aliases:
+            alias.delete()
     else:
         book.save()
-        print colored('"{}" {}'.format(book.id, 'saved' if created else 'updated'), 'green')
+        print colored('"{}" {}'.format(book.id, 'saved' if book_created else 'updated'), 'green')

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -15,7 +15,6 @@ def process_book_element(book_element):
     :param book: book element
     :returns:
     """
-
     book, book_created = Book.objects.get_or_create(pk=book_element.get('id'))
     book.title = book_element.findtext('title')
     book.description = book_element.findtext('description')

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -1,8 +1,11 @@
 # encoding: utf-8
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:58 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
+from django.db import IntegrityError
+from termcolor import colored
 
 from storage.models import Book
+from storage.models import Alias
 
 
 def process_book_element(book_element):
@@ -17,10 +20,24 @@ def process_book_element(book_element):
     book.title = book_element.findtext('title')
     book.description = book_element.findtext('description')
 
+    errors = []
     for alias in book_element.xpath('aliases/alias'):
         scheme = alias.get('scheme')
         value = alias.get('value')
 
-        book.aliases.get_or_create(scheme=scheme, value=value)
+        try:
+            book.aliases.get_or_create(scheme=scheme, value=value)
+        except IntegrityError, e:
+            # tried to create alias, but value clashed with another book's alias
+            existing_alias = Alias.objects.get(value=value)
+            errors.append('Duplicate {} found on book "{}" with value {}'.format(scheme, existing_alias.book.id, value))
 
-    book.save()
+    if errors:
+        print colored('"{}" not saved'.format(book.title), 'red')
+        for error in errors:
+            print colored(error, 'yellow')
+        if created:
+            book.delete()
+    else:
+        book.save()
+        print colored('"{}" {}'.format(book.id, 'saved' if created else 'updated'), 'green')


### PR DESCRIPTION
This is an interesting problem, and it seems like there's a lot to talk about.

The conclusion I made was that bad data should not be saved. I'm paranoid about destructive tools when they're making guesses about how to interpret input. It wasn't clear enough to me what the client was expecting with the updates, since ISBNs must be different for each printing of a book and the IDs were changing. The new titles gave away the probable aim, but I don't trust making changes on arbitrary text like that.

My changes merged in from the editions-model branch are hypothetical, in that I would have loved to talk with the user, client, and/or teammates before proceeding with it. The migrations to the Edition model are pretty hefty and irreversible, the user experience in the admin changes a bit, and the expectation of data is maybe(?) a heck of a lot different. More exploratory than anything else.

I'd argue that editions should hold uniquely identifying data and have canonical book parents for relating to each other. So the XML would have to conform to some new rules based on agreements with client, product manager, devs, and so on. I provided a new update-4.xml to show how I envisioned a new edition working.

* + An edition will be updated if the ISBN-13 matches another (barring other conflicts)
* + An edition will be created if there is no ISBN-13 match, either creating a new book with it or attaching to one based on book_id matching
* + An edition will not be saved where there are unique data conflicts (and the user will be informed)
* - No way to update ISBN-13 from the tool
* - Needs more tests!
* - Handles conflicts by not handling conflicts

Thanks! This was fun. I'd love to talk more about it.