### PR TITLE
Add an empty _local_tests.py.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 /.idea/
 
 /figgy.db.sqlite3
+
+_local_tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nosetests.xml
 /figgy.db.sqlite3
 
 _local_tests.py
+.ropeproject

--- a/figgy/_local_tests.py.example
+++ b/figgy/_local_tests.py.example
@@ -1,1 +1,6 @@
 # Place any settings overrides you need to make while testing here.
+from figgy._test_settings import *
+
+NOSE_ARGS += [
+    '--nocapture'
+]

--- a/figgy/_local_tests.py.example
+++ b/figgy/_local_tests.py.example
@@ -1,0 +1,1 @@
+# Place any settings overrides you need to make while testing here.


### PR DESCRIPTION
This file can be used to include any settings overrides you want to make
locally when writing tests. Once copied into figgy/_local_tests.py, the
file is ignored by git.