### PR TITLE
Import Books, create Conflicts for ambiguous data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,53 @@
 # Steve Smith's Code Submission
 
-I thought this was an excellent code test. Non-trivial with a nod toward the messiness of real-world development. (Wait? What? People didn't adhere to a standard?) 
+I thought this was an excellent code test. Non-trivial with a nod toward the messiness of real-world development. (Wait? What? A standard was ignored? Never.)
 
 I like that I was forced to think about some architectural things and had the freedom of a variety of solutions.
 
-Perhaps my solution is quite unlike the solution Safari Books Online chose, but I think my solution tackles the issues I thought significant in an appropriate way.
+Perhaps my solution is unlike the solution Safari Books Online chose, but I think it tackles the issues I thought significant in an appropriate way.
 
-## Key Concepts: Publisher Id & Conflicts
+I have yet to look at other pull requests; I wanted to look at this problem with fresh eyes. If we progress in the interview process I will review the other submissions and form some opinions on the relative strengths and weaknesses.
+
+## Key Concepts: Publisher Id and Conflicts
 
 The philosophy behind my solution is this: Conflicts happen. Store the conflicted data and provide another tool to correct and/or merge conflicted data. (I have not provided the merging tool; I would be happy to provide more work if that's helpful.)
 
-Another key idea is that we should not trust the publisher to give us primary key data for our database. Let's just store the publisher's id as another Alias.
+Another key idea is that we should not trust the publisher to give us primary key data for our database. Let's just store the publisher id as another Alias.
 
 ## The Task
 
-Let's get to the task at hand, shall we? Let's assume you've been through the Very First Time setup.
+Let's get to the task at hand. Let's assume you've been through the Very First Time setup.
 
 First, run the tests as originally documented:
 
     $ tox
 
-Second, reset your database to get new model changes. I did not provide migrations, because it seems
-this task seems to be a proof-of-concept situation:
+Second, reset your database to get new model changes. I did not provide migrations, because it seems this task seems to be a proof-of-concept situation:
 
     $ python manage.py reset_db <user@domain.com>
 
-This will delete the existing SQLite3 database and create the new database with the appropriate model changes. It will also create the super-user `user` with the provided email address and the password set to `user`.
+This will delete the existing SQLite database and create the new database with the appropriate model changes. It will also create the super-user `user` with the provided email address and the password set to `user`.
 
-Obviously, this method would NEVER be used on production (and will stop if your engine isn't SQLite3). But I find it useful to have a prompt-less database reset mechanism.
+Obviously, this method would NEVER be used on production (and will stop if your engine isn't SQLite). But I find it useful to have a prompt-less database reset mechanism.
 
 You should now be able to import the updates to the book data.
 
     $ python manage.py process_data_file data/initial/*.xml
     $ python manage.py process_data_file data/update/*.xml
 
-Feel free to re-run the update. We'll ignore any file that we've already processed. (We ignore duplicate updates based on the SHA1 hash of the file contents.)
+## Next Steps
 
-**The rest of this document is as it was.**
+Obviously, I have kicked most of the hard work down the road: We need a deconfliction tool. I envision a form that allows a user to examine a book's conflicts and either merge aliases/books or correct the data.
+
+I also envision a scheduled task that looks for additional conflicts in the database. I am assuming humans with keyboards could enter data as well, so we'll want to capture those issues. Lastly, the XML processor will currently not identify circular conflicts, but they would be found in the scheduled task.
+
+Conflicts could be extended to flag conflicts internal to the book itself. For example, we could create a conflict for two aliases on the same book, with different values. Or, if we want to store invalid schemes (I suspect we do), we could create a conflict for schemes that can but do not validate (such as an ISBN that fails its checksum).
+
+All in all, this task raised a lot of interesting questions and would prove a good starting point for more technical discussions. Thanks.
+
+----
+
+**The rest of this document is mostly as it was.**
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,43 @@
-# figgy
+# Steve Smith's Code Submission
 
-figgy is sample code for interviews that relates to some of the code in our content management system.
+I thought this was an excellent code test. Non-trivial with a nod toward the messiness of real-world development. (Wait? What? People didn't adhere to a standard?) 
 
-As a prospective applicant you have two options for submitting a job application:
+I like that I was forced to think about some architectural things and had the freedom of a variety of solutions.
 
-The first is to develop your own solution and submit a pull request that we will review (You can also submit your solution as a patch if you don’t wish to have your solution public on Git).  Also, if you haven’t done so, submit a resume and cover letter through our corporate site.
+Perhaps my solution is quite unlike the solution Safari Books Online chose, but I think my solution tackles the issues I thought significant in an appropriate way.
 
-Alternatively, you may review any of the currently closed pull requests in this repo.  The closed requests are a mixture of past applications, and your challenge is to pick out one approach that you would submit in lieu your own solution.  Apply through the listing for a Python engineer on our corporate site and tell us what your chosen approach would be and why.
+## Key Concepts: Publisher Id & Conflicts
 
-Pull requests to make the setup process or documentation smoother are more than welcome.
+The philosophy behind my solution is this: Conflicts happen. Store the conflicted data and provide another tool to correct and/or merge conflicted data. (I have not provided the merging tool; I would be happy to provide more work if that's helpful.)
 
+Another key idea is that we should not trust the publisher to give us primary key data for our database. Let's just store the publisher's id as another Alias.
 
-# Python
- 
+## The Task
+
+Let's get to the task at hand, shall we? Let's assume you've been through the Very First Time setup.
+
+First, run the tests as originally documented:
+
+    $ tox
+
+Second, reset your database to get new model changes. I did not provide migrations, because it seems
+this task seems to be a proof-of-concept situation:
+
+    $ python manage.py reset_db <user@domain.com>
+
+This will delete the existing SQLite3 database and create the new database with the appropriate model changes. It will also create the super-user `user` with the provided email address and the password set to `user`.
+
+Obviously, this method would NEVER be used on production (and will stop if your engine isn't SQLite3). But I find it useful to have a prompt-less database reset mechanism.
+
+You should now be able to import the updates to the book data.
+
+    $ python manage.py process_data_file data/initial/*.xml
+    $ python manage.py process_data_file data/update/*.xml
+
+Feel free to re-run the update. We'll ignore any file that we've already processed. (We ignore duplicate updates based on the SHA1 hash of the file contents.)
+
+**The rest of this document is as it was.**
+
 ## Setup
 
 ### System dependencies
@@ -31,59 +56,32 @@ This setup assumes you have just cloned the git repo and are in the directory wi
     $ python manage.py createsuperuser                     # Establish an admin so you can log in
     $ python manage.py runserver                           # Prove this works by visiting http://localhost:8000
 
-Before you write any code, make sure you can run the tests and get them to pass 100%.
+## Running tests
 
-### Every time
+I've provided decent test coverage for my solution. The tests for this project are managed by `tox`, a Python package.
 
-When you come back to work after a day or more, you'll need to update your git checkout, and make
-sure you have any new dependencies or schema modifications:
-
-    $ . ve/bin/activate                           # Turn on the virtualenv (Every time!)
-    $ python setup.py develop --always-unzip      # Update the virtualenv with new Python dependencies
-    $ python manage.py syncdb --noinput           # Make sure the database schema is still filled out
-    $ python manage.py runserver                  # Prove this works by visiting http://localhost:8000
-
-tc.
-
-## Tests
-
-The tests for this project are managed by `tox`, a Python package.
 First, install `tox` via `easy_install` (or `pip`).
 
 Prior to running tox, be sure to create a `figgy/_local_tests.py` file by copying
-`figgy/_local_tests.py.example` to `figgy/_local_tests.py`.  Any modifications to the test settings
-should be performed in the developer's `_local_test.py`.
+`figgy/_local_tests.py.example` to `figgy/_local_tests.py`. 
+
+Any modifications to the test settings should be performed in the developer's `_local_test.py`.
 
 To run the tests:
 
     tox
 
-The first run will take a while as it builds a virtualenv and installs everything in it, subsequent
-ones will be much faster.  To rebuild the virtualenv later with updated dependencies:
+The first run will take a while as it builds a virtualenv and installs everything in it, subsequent ones will be much faster.  To rebuild the virtualenv later with updated dependencies:
 
     tox -r
 
-You normally shouldn't need to recreate the tox virtualenv, since it updates itself on each run,
-but it might be necessary in cases of version conflicts.
-
+You normally shouldn't need to recreate the tox virtualenv, since it updates itself on each run, but it might be necessary in cases of version conflicts.
 
 ## Importing test data
+
 Import the initial set of test data.
 
 ````
 $ python manage.py process_data_file data/initial/*.xml
-````
-
-## The Task
-
-You received an initial set of data with very loose specs and created a basic database to manage it with. The second round of updates blew away your assumptions about how the data was formed and you are now getting a better picture. Can you implement a solution to handle the xml updates?
-
-* Feel free to do any code modifications you feel that will accomplish your task. This includes adding additional modules, models, etc.
-* Please note that the update data potentially holds bad and conflicting values.
-
-
-
-````
-$ python manage.py process_data_file data/update/*.xml
 ````
 

--- a/data/update/update-1bad.xml
+++ b/data/update/update-1bad.xml
@@ -1,0 +1,9 @@
+<book id="1000000000001">
+    <version>2.0</version>
+    <aliases>
+        <alias scheme="ISBN-10" value="1000000001"/>
+        <alias scheme="ISBN-13" value="1000000000001"/>
+
+        <alias scheme="Proprietary" value="12345ABC"/>
+    </aliases>
+</book>

--- a/data/update/update-2bad.xml
+++ b/data/update/update-2bad.xml
@@ -1,0 +1,9 @@
+<book id="12345ABC">
+    <!-- note that this id conflicts with other values -->
+    <title>this is the third book, 2nd edition</title>
+    <description>A short description about the third book. Additional Description about the third book.</description>
+    <aliases>
+        <alias scheme="ISBN-10" value="1000000003"/>
+        <alias scheme="ISBN-13" value="1000000000003"
+    </aliases>
+</book>

--- a/figgy/local.py
+++ b/figgy/local.py
@@ -1,0 +1,52 @@
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+DEBUG = True
+
+TIME_ZONE = 'UTC'
+
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)
+
+TEMPLATE_DEBUG = True
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {
+            'format': '%(module)s[%(levelname)s] %(message)s'
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+    },
+    'loggers': {
+        'figgy': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    }
+}

--- a/figgy/urls.py
+++ b/figgy/urls.py
@@ -3,10 +3,7 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'figgy.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
-
+urlpatterns = patterns(
+    '',
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ from setuptools import setup, find_packages
 version = '0.0.1'
 
 setup(
-    name="figgy",
+    name='figgy',
     version=version,
     packages=find_packages(),
     zip_safe=False,
-    description="figgy is sample code for interviews",
+    description='figgy is sample code for interviews',
     long_description="""\
 """,
     classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -25,9 +25,6 @@ setup(
     install_requires=[
         'Django>=1.6',
         'lxml>=3.2.0',
-        # 'html5lib',
-        # 'cssselect',
-
         'django-nose',
     ],
     entry_points="""

--- a/storage/admin.py
+++ b/storage/admin.py
@@ -16,7 +16,7 @@ class InlineConflictAdmin(admin.StackedInline):
 class BookAdmin(admin.ModelAdmin):
     inlines = [InlineConflictAdmin, InlineAliasAdmin]
 
-    list_display = ['id', 'title', 'list_aliases']
+    list_display = ['title', 'id', 'list_aliases']
 
     def list_aliases(self, obj):
         if obj:

--- a/storage/admin.py
+++ b/storage/admin.py
@@ -16,14 +16,29 @@ class InlineConflictAdmin(admin.StackedInline):
 class BookAdmin(admin.ModelAdmin):
     inlines = [InlineConflictAdmin, InlineAliasAdmin]
 
-    list_display = ['title', 'id', 'list_aliases']
+    list_display = ['title', 'id', 'list_aliases', 'list_conflicts']
 
     def list_aliases(self, obj):
         if obj:
-            return '<pre>%s</pre>' % '\n'.join(
-                ['%s: %s' % (o.scheme, o.value) for o in obj.aliases.all().order_by('scheme')]
+            return '<pre>{}</pre>'.format('\n'.join(
+                ['{0: <9}: {1}'.format(o.scheme, o.value)
+                 for o in obj.aliases.all().order_by('scheme')])
             )
 
     list_aliases.allow_tags = True
+
+    def list_conflicts(self, obj):
+        if obj:
+            conflicts = Conflict.objects.filter(book=obj)
+            return '<pre>{}</pre>'.format('\n'.join(
+                ['{title}: {scheme}/{value}'.format(
+                    title=conflict.alias.book.title,
+                    scheme=conflict.alias.scheme,
+                    value=conflict.alias.value)
+                 for conflict in conflicts.all().order_by('book__title')])
+            )
+
+    list_conflicts.allow_tags = True
+
 
 admin.site.register(Book, BookAdmin)

--- a/storage/admin.py
+++ b/storage/admin.py
@@ -20,5 +20,3 @@ class BookAdmin(admin.ModelAdmin):
     list_aliases.allow_tags = True
 
 admin.site.register(Book, BookAdmin)
-
-

--- a/storage/admin.py
+++ b/storage/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from storage.models import Book, Alias
+from storage.models import Alias, Book, Conflict
 
 
 class InlineAliasAdmin(admin.StackedInline):
@@ -8,14 +8,21 @@ class InlineAliasAdmin(admin.StackedInline):
     extra = 0
 
 
+class InlineConflictAdmin(admin.StackedInline):
+    model = Conflict
+    extra = 0
+
+
 class BookAdmin(admin.ModelAdmin):
-    inlines = [InlineAliasAdmin]
+    inlines = [InlineConflictAdmin, InlineAliasAdmin]
 
     list_display = ['id', 'title', 'list_aliases']
 
     def list_aliases(self, obj):
         if obj:
-            return '<pre>%s</pre>' % '\n'.join([o.value for o in obj.aliases.all()])
+            return '<pre>%s</pre>' % '\n'.join(
+                ['%s: %s' % (o.scheme, o.value) for o in obj.aliases.all().order_by('scheme')]
+            )
 
     list_aliases.allow_tags = True
 

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -26,5 +26,5 @@ class Command(BaseCommand):
                 book_node = etree.fromstring(contents)
                 msg = tools.process_book_element(book_node, filename, sha1)
                 if msg:
-                    print '!!! {0}.'.format(msg)
+                    print '... {0}.'.format(msg)
         print

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -7,7 +7,7 @@ from lxml import etree
 
 from django.core.management.base import BaseCommand
 
-import storage.tools
+import storage.tools as tools
 
 
 class Command(BaseCommand):
@@ -15,14 +15,16 @@ class Command(BaseCommand):
     help = 'Process an xml file '
 
     def handle(self, *args, **options):
-        print ''
+        print
         print 'Processing {0} titles\n'.format(len(args))
         for filename in args:
             with open(filename, 'rb') as fh:
-                print 'Importing %s into database.' % filename
-                book_node = etree.parse(fh).getroot()
-                title, conflicts = storage.tools.process_book_element(book_node)
-                print '... "{0}" processed'.format(title)
-                if conflicts:
-                    print '!!! with {0} conflicts'.format(conflicts)
-        print ''
+                contents = fh.read()
+                sha1 = tools.hash_data(contents)
+
+                print 'Importing {0} into database.'.format(filename)
+                book_node = etree.fromstring(contents)
+                msg = tools.process_book_element(book_node, filename, sha1)
+                if msg:
+                    print '!!! {0}.'.format(msg)
+        print

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -23,8 +23,12 @@ class Command(BaseCommand):
                 sha1 = tools.hash_data(contents)
 
                 print 'Importing {0} into database.'.format(filename)
-                book_node = etree.fromstring(contents)
-                msg = tools.process_book_element(book_node, filename, sha1)
-                if msg:
-                    print '... {0}.'.format(msg)
+                try:
+                    book_node = etree.fromstring(contents)
+                    conflicts = tools.process_book_element(book_node, filename, sha1)
+                    if conflicts:
+                        s = 's' if conflicts > 1 else ''
+                        print '... created with {num} conflict{s}.'.format(num=conflicts, s=s)
+                except etree.XMLSyntaxError:
+                    print('!!! Bad XML file, skipping.')
         print

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -15,8 +15,14 @@ class Command(BaseCommand):
     help = 'Process an xml file '
 
     def handle(self, *args, **options):
+        print ''
+        print 'Processing {0} titles\n'.format(len(args))
         for filename in args:
             with open(filename, 'rb') as fh:
                 print 'Importing %s into database.' % filename
                 book_node = etree.parse(fh).getroot()
-                storage.tools.process_book_element(book_node)
+                title, conflicts = storage.tools.process_book_element(book_node)
+                print '... "{0}" processed'.format(title)
+                if conflicts:
+                    print '!!! with {0} conflicts'.format(conflicts)
+        print ''

--- a/storage/management/commands/process_data_file.py
+++ b/storage/management/commands/process_data_file.py
@@ -1,10 +1,12 @@
 # encoding: utf-8
+
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:56 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
-from django.core.management.base import BaseCommand, CommandError
-
 from lxml import etree
+
+from django.core.management.base import BaseCommand
+
 import storage.tools
 
 
@@ -15,6 +17,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for filename in args:
             with open(filename, 'rb') as fh:
-                print "Importing %s into database." % filename
+                print 'Importing %s into database.' % filename
                 book_node = etree.parse(fh).getroot()
                 storage.tools.process_book_element(book_node)

--- a/storage/management/commands/reset_db.py
+++ b/storage/management/commands/reset_db.py
@@ -37,5 +37,4 @@ class Command(BaseCommand):
 
         call_command('syncdb', interactive=False)
 
-        admin = User.objects.create_superuser(username, email, username)
-        admin.save()
+        User.objects.create_superuser(username, email, username)

--- a/storage/management/commands/reset_db.py
+++ b/storage/management/commands/reset_db.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+from django.core.validators import validate_email
+from django.core.management import call_command
+
+
+class Command(BaseCommand):
+    args = '<user@host.domain>'
+    help = 'Deletes local SQLite3 db, creates superuser `user` with default password.'
+
+    def handle(self, *args, **options):
+        """ Remove SQLite database, create superuser with username as password"""
+
+        if not settings.DATABASES['default']['ENGINE'].endswith('sqlite3'):
+            print('Whoa, we only delete SQLite3 databases')
+            sys.exit(1)
+
+        if len(args) != 1:
+            print('Args: {0}\n    {1}'.format(Command.args, Command.help))
+            sys.exit(1)
+
+        try:
+            email = args[0]
+            validate_email(email)
+            username = email.split('@')[0]
+        except ValidationError:
+            print('Invalid email address')
+            sys.exit(0)
+
+        db_name = settings.DATABASES['default']['NAME']
+        os.remove(db_name)
+
+        call_command('syncdb', interactive=False)
+
+        admin = User.objects.create_superuser(username, email, username)
+        admin.save()

--- a/storage/management/commands/reset_db.py
+++ b/storage/management/commands/reset_db.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             sys.exit(1)
 
         if len(args) != 1:
-            print('Args: {0}\n    {1}'.format(Command.args, Command.help))
+            print('Args: {args}\n    {help}'.format(args=Command.args, help=Command.help))
             sys.exit(1)
 
         try:

--- a/storage/models.py
+++ b/storage/models.py
@@ -34,7 +34,7 @@ class Book(BaseModel):
         help_text='Very short description of this book.')
 
     def __unicode__(self):
-        return u'Book "{0}"'.format(self.title)
+        return u'Book "{}"'.format(self.title)
 
     class Meta:
         ordering = ['title']
@@ -61,7 +61,10 @@ class Alias(BaseModel):
         unique_together = ('book', 'scheme', 'value')
 
     def __unicode__(self):
-        return u'"{0}": {1}/{2}'.format(self.book.title, self.scheme, self.value)
+        return u'"{title}": {scheme} / {value}'.format(
+            title=self.book.title,
+            scheme=self.scheme,
+            value=self.value)
 
 
 class Conflict(BaseModel):
@@ -82,5 +85,7 @@ class Conflict(BaseModel):
         unique_together = ('book', 'alias')
 
     def __unicode__(self):
-        return u'"{0}": {1} / {2}'.format(
-            self.book.title, self.alias.scheme, self.alias.value)
+        return u'"{title}": {scheme} / {value}'.format(
+            title=self.book.title,
+            scheme=self.alias.scheme,
+            value=self.alias.value)

--- a/storage/models.py
+++ b/storage/models.py
@@ -74,14 +74,3 @@ class Conflict(BaseModel):
     def __unicode__(self):
         return u'"{0}": {1} / {2}'.format(
             self.book.title, self.conflicted_alias.scheme, self.conflicted_alias.value)
-
-
-class UpdateFile(BaseModel):
-    """Store a hash of each file we process so we can avoid re-processing identical data"""
-    filename = models.CharField(
-        max_length=255, null=False, blank=False)
-    sha1 = models.CharField(
-        max_length=40, unique=True)
-
-    def __unicode__(self):
-        return self.filename

--- a/storage/models.py
+++ b/storage/models.py
@@ -47,6 +47,9 @@ class Alias(BaseModel):
         max_length=40,
         help_text='The scheme of identifier')
 
+    class Meta:
+        unique_together = ('book', 'scheme', 'value')
+
     def __unicode__(self):
         return u'"{0}": {1}/{2}'.format(self.book.title, self.scheme, self.value)
 
@@ -64,6 +67,9 @@ class Conflict(BaseModel):
         Alias, related_name='conflicted_aliases')
     description = models.CharField(
         max_length=40, null=False, blank=False)
+
+    class Meta:
+        unique_together = ('book', 'conflicted_alias')
 
     def __unicode__(self):
         return u'"{0}": {1} / {2}'.format(

--- a/storage/models.py
+++ b/storage/models.py
@@ -28,7 +28,7 @@ class Book(BaseModel):
         help_text='Very short description of this book.')
 
     def __unicode__(self):
-        return u"Book %s" % self.title
+        return u'Book {0}'.format(self.title)
 
     class Meta:
         ordering = ['title']
@@ -51,4 +51,4 @@ class Alias(BaseModel):
         help_text='The scheme of identifier')
 
     def __unicode__(self):
-        return '%s identifier for %s' % (self.scheme, self.book.title)
+        return u'{0} identifier for {1}'.format(self.scheme, self.book.title)

--- a/storage/models.py
+++ b/storage/models.py
@@ -31,10 +31,11 @@ class Book(BaseModel):
 
 
 class Alias(BaseModel):
-    """Alternate identifiers for a given book
+    """Alternate identifiers for a given book.
 
     For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13
-    (newer scheme), or any number of other aliases.
+    (newer scheme), or any number of other aliases. In addition to the publisher-provided aliases
+    we create an alias 'PUB_ID' for the book id they provide.
     """
 
     book = models.ForeignKey(
@@ -70,6 +71,7 @@ class Conflict(BaseModel):
 
 
 class UpdateFile(BaseModel):
+    """Store a hash of each file we process so we can avoid re-processing identical data"""
     filename = models.CharField(
         max_length=255, null=False, blank=False)
     sha1 = models.CharField(

--- a/storage/models.py
+++ b/storage/models.py
@@ -67,3 +67,13 @@ class Conflict(BaseModel):
     def __unicode__(self):
         return u'"{0}": {1} / {2}'.format(
             self.book.title, self.conflicted_alias.scheme, self.conflicted_alias.value)
+
+
+class UpdateFile(BaseModel):
+    filename = models.CharField(
+        max_length=255, null=False, blank=False)
+    sha1 = models.CharField(
+        max_length=40, unique=True)
+
+    def __unicode__(self):
+        return self.filename

--- a/storage/models.py
+++ b/storage/models.py
@@ -10,6 +10,16 @@ class BaseModel(models.Model):
     last_modified_time = models.DateTimeField(
         'last-modified', auto_now=True, db_index=True)
 
+    def save(self, *args, **kwargs):
+
+        # SQLite does not honor CharField max_length; calling full_clean is one work-around to force
+        # the validation. However, this will raise a ValidationError, where as I believe most other
+        # backends will properly raise a DatabaseError.
+        # This is a temporary fix until we figure out what's next. While it works okay for
+        # processing XML files, it may not be appropriate in other cases.
+        self.full_clean()
+        super(BaseModel, self).save(*args, **kwargs)
+
     class Meta:
         abstract = True
 
@@ -66,7 +76,7 @@ class Conflict(BaseModel):
     conflicted_alias = models.ForeignKey(
         Alias, related_name='conflicted_aliases')
     description = models.CharField(
-        max_length=40, null=False, blank=False)
+        max_length=40, null=True, blank=True)
 
     class Meta:
         unique_together = ('book', 'conflicted_alias')

--- a/storage/models.py
+++ b/storage/models.py
@@ -4,22 +4,28 @@ from django.db import models
 
 
 class BaseModel(models.Model):
-    '''Base class for all models'''
-    created_time = models.DateTimeField('date created', auto_now_add=True)
-    last_modified_time = models.DateTimeField('last-modified', auto_now=True, db_index=True)
+    """Base class for all models"""
+    created_time = models.DateTimeField(
+        'date created', auto_now_add=True)
+    last_modified_time = models.DateTimeField(
+        'last-modified', auto_now=True, db_index=True)
 
     class Meta:
         abstract = True
 
 
 class Book(BaseModel):
-    '''
-    Main storage for a Book object.
-    '''
+    """Main storage for a Book object"""
 
-    id = models.CharField(max_length=30, primary_key=True, help_text="The primary identifier of this title, we get this value from publishers.")
-    title = models.CharField(max_length=128, help_text="The title of this book.", db_index=True, null=False, blank=False)
-    description = models.TextField(blank=True, null=True, default=None, help_text="Very short description of this book.")
+    id = models.CharField(
+        max_length=30, primary_key=True,
+        help_text='The primary identifier of this title, we get this value from publishers.')
+    title = models.CharField(
+        max_length=128, db_index=True, null=False, blank=False,
+        help_text='The title of this book.')
+    description = models.TextField(
+        blank=True, null=True, default=None,
+        help_text='Very short description of this book.')
 
     def __unicode__(self):
         return u"Book %s" % self.title
@@ -29,16 +35,20 @@ class Book(BaseModel):
 
 
 class Alias(BaseModel):
-    '''
-    A book can have one or more aliases which
+    """Alternate identifiers for a given book
 
-    For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13 (newer scheme),
-    or any number of other aliases.
-    '''
+    For example, a book can be referred to with an ISBN-10 (older, deprecated scheme), ISBN-13
+    (newer scheme), or any number of other aliases.
+    """
 
-    book = models.ForeignKey(Book, related_name='aliases')
-    value = models.CharField(max_length=255, db_index=True, unique=True, help_text="The value of this identifier")
-    scheme = models.CharField(max_length=40, help_text="The scheme of identifier")
+    book = models.ForeignKey(
+        Book, related_name='aliases')
+    value = models.CharField(
+        max_length=255, db_index=True, unique=True,
+        help_text='The value of this identifier')
+    scheme = models.CharField(
+        max_length=40,
+        help_text='The scheme of identifier')
 
     def __unicode__(self):
         return '%s identifier for %s' % (self.scheme, self.book.title)

--- a/storage/models.py
+++ b/storage/models.py
@@ -72,15 +72,15 @@ class Conflict(BaseModel):
     and allows someone to manage conflicts (merge or correct and mark distinct).
     """
     book = models.ForeignKey(
-        Book, related_name='books')
-    conflicted_alias = models.ForeignKey(
+        Book, related_name='conflicted_books')
+    alias = models.ForeignKey(
         Alias, related_name='conflicted_aliases')
     description = models.CharField(
         max_length=40, null=True, blank=True)
 
     class Meta:
-        unique_together = ('book', 'conflicted_alias')
+        unique_together = ('book', 'alias')
 
     def __unicode__(self):
         return u'"{0}": {1} / {2}'.format(
-            self.book.title, self.conflicted_alias.scheme, self.conflicted_alias.value)
+            self.book.title, self.alias.scheme, self.alias.value)

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -2,8 +2,6 @@
 
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
-import uuid
-
 from django.test import TestCase
 
 from storage import models
@@ -11,32 +9,35 @@ from storage import models
 
 class TestModels(TestCase):
     def setUp(self):
-        self.book = models.Book.objects.create(title='The Title', pk=str(uuid.uuid4()))
+        self.book = models.Book.objects.create(title='The Title', pk=42)
 
     def test_book_has_unicode_method(self):
         """Book should have a __unicode__ method."""
-        expected = u'Book {0}'.format(self.book.title)
+        expected = u'Book "{0}"'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
 
     def test_book_unicode_handles_non_ascii(self):
         """Book __unicode__ should handle non-ascii."""
         self.book.title = u'El Título'
-        expected = u'Book El Título'
+        expected = u'Book "El Título"'
         self.assertEquals(expected, unicode(self.book))
 
 
 class TestAlias(TestCase):
     def setUp(self):
-        self.book = models.Book.objects.create(title=u'El Título', pk=str(uuid.uuid4()))
+        self.book = models.Book.objects.create(title=u'El Título', pk=42)
         self.alias = models.Alias.objects.create(book_id=self.book.id, scheme='Foobar', value='42')
 
     def test_alias_has_unicode_method(self):
         """Alias should have a __unicode__ method."""
-        expected = u'{0} identifier for {1}'.format(self.alias.scheme, self.book.title)
-        self.assertEquals(expected, unicode(self.alias))
+        alias = self.alias
+        expected = u'"{0}": {1}/{2}'.format(self.book.title, alias.scheme, alias.value)
+        self.assertEquals(expected, unicode(alias))
 
     def test_alias_unicode_handles_non_ascii(self):
         """Alias __unicode__ should handle non-ascii."""
         self.alias.scheme = u'FØØ-12'
-        expected = u'FØØ-12 identifier for {0}'.format(self.book.title)
+        self.alias.value = u'12345'
+        expected = u'"{0}": FØØ-12/12345'.format(self.book.title)
         self.assertEquals(expected, unicode(self.alias))
+

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
-'''
-Copyright (c) 2013 Safari Books Online. All rights reserved.
-'''
+
+# Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
 import uuid
 
@@ -9,13 +8,12 @@ from django.test import TestCase
 
 from storage import models
 
+
 class TestModels(TestCase):
     def setUp(self):
-        self.book = models.Book.objects.create(title="The Title", pk=str(uuid.uuid4()))
+        self.book = models.Book.objects.create(title='The Title', pk=str(uuid.uuid4()))
 
     def test_book_have_unicode_method(self):
-        '''The Book should have a __unicode__ method.'''
+        """The Book should have a __unicode__ method."""
         expected = 'Book {}'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
-
-

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
+from django.core.exceptions import ValidationError
 
 from django.test import TestCase
 
@@ -13,7 +14,7 @@ class TestBook(TestCase):
 
     def test_book_has_unicode_method(self):
         """Book should have a __unicode__ method."""
-        expected = u'Book "{0}"'.format(self.book.title)
+        expected = u'Book "{}"'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
 
     def test_book_unicode_handles_non_ascii(self):
@@ -21,6 +22,12 @@ class TestBook(TestCase):
         self.book.title = u'El Título'
         expected = u'Book "El Título"'
         self.assertEquals(expected, unicode(self.book))
+
+    def test_book_save_method_raises_error_on_title_overflow(self):
+        """book.save() should raise an error if title exceeds max length"""
+        self.book.title = 'X' * 1000
+        with self.assertRaises(ValidationError):
+            self.book.save()
 
 
 class TestAlias(TestCase):
@@ -31,12 +38,24 @@ class TestAlias(TestCase):
     def test_alias_has_unicode_method(self):
         """Alias should have a __unicode__ method."""
         alias = self.alias
-        expected = u'"{0}": {1}/{2}'.format(self.book.title, alias.scheme, alias.value)
+        expected = u'"{}": {} / {}'.format(self.book.title, alias.scheme, alias.value)
         self.assertEquals(expected, unicode(alias))
 
     def test_alias_unicode_handles_non_ascii(self):
         """Alias __unicode__ should handle non-ascii."""
         self.alias.scheme = u'FØØ-12'
         self.alias.value = u'12345'
-        expected = u'"{0}": FØØ-12/12345'.format(self.book.title)
+        expected = u'"{}": FØØ-12 / 12345'.format(self.book.title)
         self.assertEquals(expected, unicode(self.alias))
+
+    def test_book_save_method_raises_error_on_scheme_overflow(self):
+        """Alias.save() should raise an error if scheme exceeds max length"""
+        self.alias.scheme = 'X' * 1000
+        with self.assertRaises(ValidationError):
+            self.alias.save()
+
+    def test_book_save_method_raises_error_on_value_overflow(self):
+        """Alias.save() should raise an error if value exceeds max length"""
+        self.alias.scheme = 'X' * 1000
+        with self.assertRaises(ValidationError):
+            self.alias.save()

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -40,21 +40,3 @@ class TestAlias(TestCase):
         self.alias.value = u'12345'
         expected = u'"{0}": FØØ-12/12345'.format(self.book.title)
         self.assertEquals(expected, unicode(self.alias))
-
-
-class TestUpdateFile(TestCase):
-
-    def setUp(self):
-        sha1 = tools.hash_data('foobar')
-        self.update_file = models.UpdateFile.objects.create(filename='update-1.xml', sha1=sha1)
-
-    def test_alias_has_unicode_method(self):
-        """UpdateFile should have a __unicode__ method."""
-        expected = u'{0}'.format(self.update_file.filename)
-        self.assertEquals(expected, unicode(self.update_file))
-
-    def test_alias_unicode_handles_non_ascii(self):
-        """UpdateFile __unicode__ should handle non-ascii."""
-        self.update_file.filename = u'üpdate-1.xml'
-        expected = u'{0}'.format(self.update_file.filename)
-        self.assertEquals(expected, unicode(self.update_file))

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -9,7 +9,7 @@ from storage import models, tools
 
 class TestModels(TestCase):
     def setUp(self):
-        self.book = models.Book.objects.create(title='The Title', pk=42)
+        self.book = models.Book.objects.create(title='The Title')
 
     def test_book_has_unicode_method(self):
         """Book should have a __unicode__ method."""
@@ -25,7 +25,7 @@ class TestModels(TestCase):
 
 class TestAlias(TestCase):
     def setUp(self):
-        self.book = models.Book.objects.create(title=u'El Título', pk=42)
+        self.book = models.Book.objects.create(title=u'El Título')
         self.alias = models.Alias.objects.create(book_id=self.book.id, scheme='Foobar', value='42')
 
     def test_alias_has_unicode_method(self):

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -13,7 +13,30 @@ class TestModels(TestCase):
     def setUp(self):
         self.book = models.Book.objects.create(title='The Title', pk=str(uuid.uuid4()))
 
-    def test_book_have_unicode_method(self):
-        """The Book should have a __unicode__ method."""
-        expected = 'Book {}'.format(self.book.title)
+    def test_book_has_unicode_method(self):
+        """Book should have a __unicode__ method."""
+        expected = u'Book {0}'.format(self.book.title)
         self.assertEquals(expected, unicode(self.book))
+
+    def test_book_unicode_handles_non_ascii(self):
+        """Book __unicode__ should handle non-ascii."""
+        self.book.title = u'El Título'
+        expected = u'Book El Título'
+        self.assertEquals(expected, unicode(self.book))
+
+
+class TestAlias(TestCase):
+    def setUp(self):
+        self.book = models.Book.objects.create(title=u'El Título', pk=str(uuid.uuid4()))
+        self.alias = models.Alias.objects.create(book_id=self.book.id, scheme='Foobar', value='42')
+
+    def test_alias_has_unicode_method(self):
+        """Alias should have a __unicode__ method."""
+        expected = u'{0} identifier for {1}'.format(self.alias.scheme, self.book.title)
+        self.assertEquals(expected, unicode(self.alias))
+
+    def test_alias_unicode_handles_non_ascii(self):
+        """Alias __unicode__ should handle non-ascii."""
+        self.alias.scheme = u'FØØ-12'
+        expected = u'FØØ-12 identifier for {0}'.format(self.book.title)
+        self.assertEquals(expected, unicode(self.alias))

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -4,10 +4,10 @@
 
 from django.test import TestCase
 
-from storage import models, tools
+from storage import models
 
 
-class TestModels(TestCase):
+class TestBook(TestCase):
     def setUp(self):
         self.book = models.Book.objects.create(title='The Title')
 

--- a/storage/tests/test_models.py
+++ b/storage/tests/test_models.py
@@ -4,7 +4,7 @@
 
 from django.test import TestCase
 
-from storage import models
+from storage import models, tools
 
 
 class TestModels(TestCase):
@@ -41,3 +41,20 @@ class TestAlias(TestCase):
         expected = u'"{0}": FØØ-12/12345'.format(self.book.title)
         self.assertEquals(expected, unicode(self.alias))
 
+
+class TestUpdateFile(TestCase):
+
+    def setUp(self):
+        sha1 = tools.hash_data('foobar')
+        self.update_file = models.UpdateFile.objects.create(filename='update-1.xml', sha1=sha1)
+
+    def test_alias_has_unicode_method(self):
+        """UpdateFile should have a __unicode__ method."""
+        expected = u'{0}'.format(self.update_file.filename)
+        self.assertEquals(expected, unicode(self.update_file))
+
+    def test_alias_unicode_handles_non_ascii(self):
+        """UpdateFile __unicode__ should handle non-ascii."""
+        self.update_file.filename = u'üpdate-1.xml'
+        expected = u'{0}'.format(self.update_file.filename)
+        self.assertEquals(expected, unicode(self.update_file))

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -79,8 +79,9 @@ class TestSupportingTools(TestCase):
 
     def test_hash_file(self):
         """hash_file should return a git compatible SHA1"""
-        # To get expected sha1 value (be sure to use -e):
-        # $ echo -e foobar\n | git hash-object --stdin
+
+        # To get expected sha1 value
+        # $ echo foobar\n | git hash-object --stdin
 
         expected = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
         self.assertEqual(tools.hash_data(''), expected)
@@ -113,7 +114,7 @@ class TestSupportingTools(TestCase):
         self.assertEqual(len(aliases), 2)
 
     def test_parse_book_element(self):
-        """parse_book_element should parse XML data into dict of appropriate values"""
+        """extract_book_data should extract data from XML into dict of appropriate values"""
         book_element_str = """
         <book id="123">
             <title>The Title</title>
@@ -125,7 +126,7 @@ class TestSupportingTools(TestCase):
         </book>
         """
         book_element = etree.fromstring(book_element_str)
-        data = tools.parse_book_element(book_element)
+        data = tools.extract_book_data(book_element)
         self.assertEqual(data['publisher_id'], '123')
         self.assertEqual(data['title'], 'The Title')
         self.assertEqual(data['description'], 'The desc')
@@ -158,7 +159,7 @@ class TestProcessingConflicts(TestCase):
         self.assertEqual(conflicts[0].value, 'THAT')
 
     def test_get_alias_conflicts_ignores_itself(self):
-        """get_alias_conflicts should return an empty list if no new conflicts in incoming data"""
+        """get_alias_conflicts should return empty list if incoming data has no conflicts"""
         new_book = Book.objects.get(title='The Title')
         incoming_aliases = [
             {'scheme': 'THIS', 'value': 'THAT'},

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -32,9 +32,10 @@ class TestTools(TestCase):
         storage.tools.process_book_element(xml)
 
         self.assertEqual(Book.objects.count(), 1)
-        book = Book.objects.get(pk='12345')
+        book = Book.objects.get(title=u'El Título')
 
         self.assertEqual(book.title, u'El Título')
-        self.assertEqual(book.aliases.count(), 2)
+        self.assertEqual(book.aliases.count(), 3)
         self.assertEqual(Alias.objects.get(scheme='ISBN-10').value, '0158757819')
         self.assertEqual(Alias.objects.get(scheme='ISBN-13').value, '0000000000123')
+        self.assertEqual(Alias.objects.get(scheme='PUB_ID').value, '12345')

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -18,15 +18,15 @@ class TestTools(TestCase):
     def test_storage_tools_process_book_element_db(self):
         """process_book_element should put the book in the database."""
 
-        xml_str = '''
+        xml_str = u"""
         <book id="12345">
-            <title>A title</title>
+            <title>El Título</title>
             <aliases>
                 <alias scheme="ISBN-10" value="0158757819"/>
                 <alias scheme="ISBN-13" value="0000000000123"/>
             </aliases>
         </book>
-        '''
+        """
 
         xml = etree.fromstring(xml_str)
         storage.tools.process_book_element(xml)
@@ -34,7 +34,7 @@ class TestTools(TestCase):
         self.assertEqual(Book.objects.count(), 1)
         book = Book.objects.get(pk='12345')
 
-        self.assertEqual(book.title, 'A title')
+        self.assertEqual(book.title, u'El Título')
         self.assertEqual(book.aliases.count(), 2)
         self.assertEqual(Alias.objects.get(scheme='ISBN-10').value, '0158757819')
         self.assertEqual(Alias.objects.get(scheme='ISBN-13').value, '0000000000123')

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -115,7 +115,7 @@ class TestProcessBookElement(TestCase):
         self.assertEqual(Alias.objects.count(), 0)
 
     def test_storage_tools_populate_and_save_fails_on_alias_overflow(self):
-        """populate_and_save should fail when alias fields overflow"""
+        """populate_and_save should not store aliases OR book when alias fields overflow"""
         book = Book()
         incoming = {
             'publisher_id': '123',

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -1,9 +1,12 @@
 # encoding: utf-8
+
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 5:01 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
-from django.test import TestCase
 from lxml import etree
+
+from django.test import TestCase
+
 from storage.models import Book, Alias
 import storage.tools
 
@@ -13,7 +16,7 @@ class TestTools(TestCase):
         pass
 
     def test_storage_tools_process_book_element_db(self):
-        '''process_book_element should put the book in the database.'''
+        """process_book_element should put the book in the database."""
 
         xml_str = '''
         <book id="12345">
@@ -35,4 +38,3 @@ class TestTools(TestCase):
         self.assertEqual(book.aliases.count(), 2)
         self.assertEqual(Alias.objects.get(scheme='ISBN-10').value, '0158757819')
         self.assertEqual(Alias.objects.get(scheme='ISBN-13').value, '0000000000123')
-

--- a/storage/tests/test_tools.py
+++ b/storage/tests/test_tools.py
@@ -7,18 +7,13 @@ from lxml import etree
 
 from django.test import TestCase
 
-from storage.models import Book, Alias
-import storage.tools
+from storage.models import Book, Alias, Conflict, UpdateFile
+import storage.tools as tools
 
 
-class TestTools(TestCase):
+class TestProcessBookElement(TestCase):
     def setUp(self):
-        pass
-
-    def test_storage_tools_process_book_element_db(self):
-        """process_book_element should put the book in the database."""
-
-        xml_str = u"""
+        self.xml_str = u"""
         <book id="12345">
             <title>El Título</title>
             <aliases>
@@ -27,9 +22,12 @@ class TestTools(TestCase):
             </aliases>
         </book>
         """
+        self.hash = 'A' * 40
 
-        xml = etree.fromstring(xml_str)
-        storage.tools.process_book_element(xml)
+    def test_storage_tools_process_book_element_db(self):
+        """process_book_element should put the book in the database."""
+        xml = etree.fromstring(self.xml_str)
+        tools.process_book_element(xml, 'filename', self.hash)
 
         self.assertEqual(Book.objects.count(), 1)
         book = Book.objects.get(title=u'El Título')
@@ -39,3 +37,131 @@ class TestTools(TestCase):
         self.assertEqual(Alias.objects.get(scheme='ISBN-10').value, '0158757819')
         self.assertEqual(Alias.objects.get(scheme='ISBN-13').value, '0000000000123')
         self.assertEqual(Alias.objects.get(scheme='PUB_ID').value, '12345')
+
+    def test_storage_tools_reprocess_same_file(self):
+        """process_book_element should not reprocess an identical file"""
+        xml = etree.fromstring(self.xml_str)
+        tools.process_book_element(xml, 'filename', self.hash)
+        self.assertEqual(Book.objects.count(), 1)
+
+        book = Book.objects.get(title=u'El Título')
+        self.assertEqual(book.aliases.count(), 3)
+        self.assertEqual(Conflict.objects.count(), 0)
+        self.assertEqual(UpdateFile.objects.count(), 1)
+
+        # process an update that will generate new book, aliases and conflicts
+        xml_update_str = u"""
+        <book id="789">
+            <title>El Título, 2e</title>
+            <aliases>
+                <alias scheme="ISBN-10" value="0158757819"/>
+                <alias scheme="ISBN-13" value="0000000000123"/>
+            </aliases>
+        </book>
+        """
+        xml = etree.fromstring(xml_update_str)
+        bogus_hash = '2' * 40
+        tools.process_book_element(xml, 'filename2', bogus_hash)
+        self.assertEqual(Book.objects.count(), 2)
+        self.assertEqual(Alias.objects.count(), 6)
+        self.assertEqual(Conflict.objects.count(), 2)
+        self.assertEqual(UpdateFile.objects.count(), 2)
+
+        # ... DO NOT process it again, even if we try
+        tools.process_book_element(xml, 'filename2', bogus_hash)
+        self.assertEqual(Book.objects.count(), 2)
+        self.assertEqual(Alias.objects.count(), 6)
+        self.assertEqual(Conflict.objects.count(), 2)
+        self.assertEqual(UpdateFile.objects.count(), 2)
+
+
+class TestSupportingTools(TestCase):
+
+    def test_hash_file(self):
+        """hash_file should return a git compatible SHA1"""
+        # To get expected sha1 value (be sure to use -e):
+        # $ echo -e foobar\n | git hash-object --stdin
+
+        expected = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
+        self.assertEqual(tools.hash_data(''), expected)
+
+        expected = '323fae03f4606ea9991df8befbb2fca795e648fa'
+        self.assertEqual(tools.hash_data('foobar\n'), expected)
+
+    def test_populate_book_attrs(self):
+        """populate_book_attrs should populate Book attrs with incoming and return pub_id alias"""
+        book = Book.objects.create()
+        aliases = {'aliases': [
+            {'scheme': 'PUB_ID', 'value': '123'},
+            {'scheme': 'FOO', 'value': 'BAR'}
+        ]}
+        incoming = {
+            'publisher_id': '123',
+            'title': 'The Title',
+            'description': 'Exciting new book',
+            'aliases': aliases
+        }
+
+        incoming.update(aliases)
+        book, pub_id_alias = tools.populate_book_attrs(book, incoming)
+        self.assertEqual(book.title, incoming['title'])
+        self.assertEqual(book.description, incoming['description'])
+        self.assertEqual(pub_id_alias.scheme, 'PUB_ID')
+        self.assertEqual(pub_id_alias.value, '123')
+        book.save()
+        aliases = Alias.objects.filter(book=book)
+        self.assertEqual(len(aliases), 2)
+
+    def test_parse_book_element(self):
+        """parse_book_element should parse XML data into dict of appropriate values"""
+        book_element_str = """
+        <book id="123">
+            <title>The Title</title>
+            <description>The desc</description>
+            <aliases>
+                <alias scheme="THIS" value="THAT"/>
+                <alias scheme="FOO" value="BAR"/>
+            </aliases>
+        </book>
+        """
+        book_element = etree.fromstring(book_element_str)
+        data = tools.parse_book_element(book_element)
+        self.assertEqual(data['publisher_id'], '123')
+        self.assertEqual(data['title'], 'The Title')
+        self.assertEqual(data['description'], 'The desc')
+        self.assertEqual(data['aliases'], [
+            {'scheme': 'THIS', 'value': 'THAT'},
+            {'scheme': 'FOO', 'value': 'BAR'},
+        ])
+
+
+class TestProcessingConflicts(TestCase):
+
+    def setUp(self):
+        existing_book = Book.objects.create(title='The Title')
+        existing_book.aliases.create(scheme='PUB_ID', value='123')
+        existing_book.aliases.create(scheme='THIS', value='THAT')
+        existing_book.aliases.create(scheme='FOO', value='BAR')
+        existing_book.save()
+        self.existing_book = existing_book
+
+    def test_get_alias_conflicts_one_existing_alias(self):
+        """get_alias_conflicts should return a list of Alias conflict with book.aliases"""
+
+        new_book = Book.objects.create(title='Ninjas are For Movies')
+        incoming_aliases = [
+            {'scheme': 'THIS', 'value': 'THAT'},
+        ]
+        conflicts = tools.get_alias_conflicts(new_book, incoming_aliases)
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(conflicts[0].scheme, 'THIS')
+        self.assertEqual(conflicts[0].value, 'THAT')
+
+    def test_get_alias_conflicts_ignores_itself(self):
+        """get_alias_conflicts should return an empty list if no new conflicts in incoming data"""
+        new_book = Book.objects.get(title='The Title')
+        incoming_aliases = [
+            {'scheme': 'THIS', 'value': 'THAT'},
+        ]
+        conflicts = tools.get_alias_conflicts(new_book, incoming_aliases)
+        self.assertEqual(conflicts, [])

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -3,16 +3,26 @@
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:58 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
-from storage.models import Alias, Book, Conflict
+import hashlib
+
+from storage.models import Alias, Book, Conflict, UpdateFile
 
 
-def process_book_element(book_element):
+def process_book_element(book_element, filename, sha1):
     """Process a book element into the database.
 
     We store the published id as another aliases. If we have any alias conflicts (including pub_id)
     we create a Conflict object so we can research and fix the issue. Possible resolutions can
     include correcting the data or merging aliases to point to the canonical book.
     """
+
+    updated_already = UpdateFile.objects.filter(sha1=sha1)
+    if updated_already:
+        update_file = updated_already[0]
+        prev_filename = update_file.filename
+        created_str = update_file.created_time.strftime('%c')
+        return '{0} processed on {1} contained same data'.format(prev_filename, created_str)
+
     incoming = parse_book_element(book_element)
     found = Alias.objects.filter(value=incoming['publisher_id'])
     num_found = len(found)
@@ -24,7 +34,12 @@ def process_book_element(book_element):
     conflicted_aliases = get_alias_conflicts(book, incoming['aliases'])
     conflicted_aliases = conflicted_aliases + list(found) if num_found > 1 else conflicted_aliases
     num_conflicts = create_conflicts(book, set(conflicted_aliases))
-    return book.title, num_conflicts
+
+    msg = ''
+    if num_conflicts:
+        msg = 'created with {0} conflicts'.format(num_conflicts)
+    UpdateFile.objects.create(filename=filename, sha1=sha1)
+    return msg
 
 
 def create_conflicts(book, alias_set):
@@ -38,14 +53,14 @@ def create_conflicts(book, alias_set):
     return created
 
 
-def get_alias_conflicts(book, aliases):
+def get_alias_conflicts(book, incoming_aliases):
     """Return a list of Alias records match the alias data provided by incoming book"""
     conflicts = []
-    for incoming_alias in aliases:
+    for incoming_alias in incoming_aliases:
         scheme = incoming_alias['scheme']
         value = incoming_alias['value']
         conflicts.append(Alias.objects.filter(scheme=scheme, value=value).exclude(book=book))
-    # Filtering means we get back a list of zero or more possible aliases, flatten that
+    # Flatten list of lists; filtering results in list of zero or more aliases appended to conflicts
     flattened_conflicts = [item for found_set in conflicts for item in found_set]
     return flattened_conflicts
 
@@ -71,7 +86,25 @@ def populate_book_attrs(book, incoming):
     """Populate book object with values from incoming dict, including an alias for publisher id"""
     book.title = incoming['title']
     book.description = incoming['description']
+
     for alias in incoming['aliases']:
         book.aliases.get_or_create(scheme=alias['scheme'], value=alias['value'])
+
     alias, created = book.aliases.get_or_create(scheme='PUB_ID', value=incoming['publisher_id'])
     return book, alias
+
+
+def hash_data(contents):
+    """Return a git-compatible sha1 hash for data, usually contents of file
+
+    Using git-compatible hash since we may have the data files stored in git. Could be handy.
+    If we get out of sync with the git format reason it shouldn't kill us.
+
+    This is simple enough that it makes sense to implement here, rather than spawning a new process.
+    """
+    data = contents
+    len_data = len(data)
+    sha1 = hashlib.sha1()
+    sha1.update('blob {0}\0'.format(len_data))
+    sha1.update(contents)
+    return sha1.hexdigest()

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -3,25 +3,75 @@
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:58 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
-from storage.models import Book
+from storage.models import Alias, Book, Conflict
 
 
 def process_book_element(book_element):
+    """Process a book element into the database.
+
+    We store the published id as another aliases. If we have any alias conflicts (including pub_id)
+    we create a Conflict object so we can research and fix the issue. Possible resolutions can
+    include correcting the data or merging aliases to point to the canonical book.
     """
-    Process a book element into the database.
+    incoming = parse_book_element(book_element)
+    found = Alias.objects.filter(value=incoming['publisher_id'])
+    num_found = len(found)
 
-    :param book_element: root element describing a book
-    :returns:
-    """
-
-    book, created = Book.objects.get_or_create(pk=book_element.get('id'))
-    book.title = book_element.findtext('title')
-    book.description = book_element.findtext('description')
-
-    for alias in book_element.xpath('aliases/alias'):
-        scheme = alias.get('scheme')
-        value = alias.get('value')
-
-        book.aliases.get_or_create(scheme=scheme, value=value)
-
+    book = found[0].book if num_found == 1 else Book.objects.create()
+    book, pub_id_alias = populate_book_attrs(book, incoming)
     book.save()
+
+    conflicted_aliases = get_alias_conflicts(book, incoming['aliases'])
+    conflicted_aliases = conflicted_aliases + list(found) if num_found > 1 else conflicted_aliases
+    num_conflicts = create_conflicts(book, set(conflicted_aliases))
+    return book.title, num_conflicts
+
+
+def create_conflicts(book, alias_set):
+    """Create a Conflict object for each alias duplicate; return number created"""
+    created = 0
+    for alias in alias_set:
+        conflict, created = Conflict.objects.get_or_create(book=book, conflicted_alias=alias)
+        conflict.description = '[Auto] created on import'
+        conflict.save()
+        created += 1
+    return created
+
+
+def get_alias_conflicts(book, aliases):
+    """Return a list of Alias records match the alias data provided by incoming book"""
+    conflicts = []
+    for incoming_alias in aliases:
+        scheme = incoming_alias['scheme']
+        value = incoming_alias['value']
+        conflicts.append(Alias.objects.filter(scheme=scheme, value=value).exclude(book=book))
+    # Filtering means we get back a list of zero or more possible aliases, flatten that
+    flattened_conflicts = [item for found_set in conflicts for item in found_set]
+    return flattened_conflicts
+
+
+def parse_book_element(book_element):
+    """Parse the book data, return a dictionary of values"""
+    publisher_id = book_element.get('id')
+    title = book_element.findtext('title')    
+    description = book_element.findtext('description')
+
+    aliases = []
+    for alias in book_element.xpath('aliases/alias'):
+        aliases.append({'scheme': alias.get('scheme'), 'value': alias.get('value')})
+
+    return {
+        'publisher_id': publisher_id,
+        'title': title,
+        'description': description,
+        'aliases': aliases}
+    
+
+def populate_book_attrs(book, incoming):
+    """Populate book object with values from incoming dict, including an alias for publisher id"""
+    book.title = incoming['title']
+    book.description = incoming['description']
+    for alias in incoming['aliases']:
+        book.aliases.get_or_create(scheme=alias['scheme'], value=alias['value'])
+    alias, created = book.aliases.get_or_create(scheme='PUB_ID', value=incoming['publisher_id'])
+    return book, alias

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -27,19 +27,15 @@ def process_book_element(book_element, filename, sha1):
 
     incoming = extract_book_data(book_element)
     book, num_conflicts = store_book_with_conflicts(incoming)
-
-    msg = ''
-    if num_conflicts:
-        msg = 'created with {0} conflicts'.format(num_conflicts)
     UpdateFile.objects.create(filename=filename, sha1=sha1)
-    return msg
+    return num_conflicts
 
 
 def store_book_with_conflicts(incoming):
     """Given a dict of incoming data, persist a Book, its Aliases, and and any Conflicts
 
     Since this takes an incoming dictionary, it could work just fine with the results of
-    a form's cleaned_data output with similar structure..
+    a form's cleaned_data output with similar structure.
     """
     found = Alias.objects.filter(scheme='PUB_ID', value=incoming['publisher_id'])
     num_found = found.count()

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -46,7 +46,7 @@ def create_conflicts(book, dupe_aliases):
     """Create a Conflict object for each alias duplicate; return count of newly created Conflicts"""
     num_created = 0
     for alias in dupe_aliases:
-        conflict, created = Conflict.objects.get_or_create(book=book, conflicted_alias=alias)
+        conflict, created = Conflict.objects.get_or_create(book=book, alias=alias)
         num_created = num_created + 1 if created else num_created
     return num_created
 

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -65,6 +65,8 @@ def get_alias_conflicts(book):
 def populate_and_save(book, incoming):
     """Populate book object with values from incoming dict and save the Book/Aliases"""
 
+    # Save book AND aliases as one transaction; an error in alias
+    # creation would leave a book without complete alias data.
     with transaction.atomic():
         book.title = incoming['title']
         book.description = incoming['description']

--- a/storage/tools.py
+++ b/storage/tools.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 # Created by David Rideout <drideout@safaribooksonline.com> on 2/7/14 4:58 PM
 # Copyright (c) 2013 Safari Books Online, LLC. All rights reserved.
 
@@ -9,7 +10,7 @@ def process_book_element(book_element):
     """
     Process a book element into the database.
 
-    :param book: book element
+    :param book_element: root element describing a book
     :returns:
     """
 

--- a/storage/views.py
+++ b/storage/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
This PR acknowledges the existence of bad data. It imports a book into the database and then records a record of any conflicted data.

One significant change that seems appropriate, but needs discussions, is the choice to move the publisher-provided book_id into an alias and using our own synthetic primary key for Book. I think this is sound on the general principle of not trusting user input. But I'm not aware of all the forces at play.

This PR kicks the work down the road. We'll need to create the amusingly named Deconflict (Deconfliction?) tool. This tool will start out as a human-driven merge/auditing tool. As we progress we can automate certain error patterns.

